### PR TITLE
Add note about mocked credit purchase

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,8 @@ flask run
 ```
 
 4. Configure your Twilio phone number's webhook to point to `/sms` on your server.
+
+## Limitations
+
+Credit purchasing is currently mocked for demonstration purposes and is **not**
+integrated with Stripe yet.


### PR DESCRIPTION
## Summary
- document that credit purchasing is mocked and not yet connected to Stripe

## Testing
- `python -m py_compile app.py models.py config.py`