### PR TITLE
Add Stripe payment integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # smsGPT
 
 A simple Flask app that authenticates users via phone using Twilio Verify. Users can purchase up to $20 of credit and interact with OpenRouter's Gemini model via SMS. Each message sent or received deducts a small amount of credit.
+Payments for credit are handled through Stripe Checkout.
 
 ## Setup
 
@@ -11,6 +12,8 @@ pip install -r requirements.txt
 ```
 
 2. Copy `.env.example` to `.env` and fill in your credentials. Make sure `SECRET_KEY` is a secure random value (e.g. `openssl rand -hex 32`).
+
+   You'll also need a Stripe secret key in `STRIPE_SECRET_KEY` to enable credit purchases.
 
 3. Run the app:
 

--- a/models.py
+++ b/models.py
@@ -21,3 +21,13 @@ class MessageLog(db.Model):
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
     cost = db.Column(db.Float, default=0.0)
 
+
+class Payment(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    session_id = db.Column(db.String(255), unique=True, nullable=False)
+    amount = db.Column(db.Float, nullable=False)
+    status = db.Column(db.String(50), default='pending')
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask
 flask_sqlalchemy
 requests
 twilio
+stripe

--- a/templates/purchase.html
+++ b/templates/purchase.html
@@ -6,4 +6,5 @@
   <label>Amount (max $20):</label>
   <input type="number" step="0.01" name="amount" max="20" required>
   <button type="submit">Add Credit</button>
+  <p>You will be redirected to Stripe to complete the payment.</p>
 </form>


### PR DESCRIPTION
## Summary
- add payment via Stripe Checkout
- track Stripe sessions with new `Payment` model
- update purchase handler and add success callback
- note Stripe use in README
- show redirect message on purchase page
- depend on `stripe` library

## Testing
- `python -m py_compile app.py models.py config.py`